### PR TITLE
Fixing the Github Actions ImageMagick Compatibility

### DIFF
--- a/.github/workflows/deploy-to-build-dev.yml
+++ b/.github/workflows/deploy-to-build-dev.yml
@@ -13,8 +13,16 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Setup ImageMagick
-        uses: mfinelli/setup-imagemagick@v6.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Install Node Dependencies
+        run: npm install
+
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
 
       - name: Set up ImageMagick alias
         run: |
@@ -29,14 +37,6 @@ jobs:
             echo "Alias 'convert' not found!"
             exit 1
           fi
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-
-      - name: Install Node Dependencies
-        run: npm install
 
       - name: Build App
         run: npm run build-all


### PR DESCRIPTION
Looking if this temporal solution will work, based on the necessity of the deprecated convert command of ImageMagick.